### PR TITLE
Don't sleep if negative (#123)

### DIFF
--- a/src/githubcity/ghcity.py
+++ b/src/githubcity/ghcity.py
@@ -527,7 +527,9 @@ class GitHubCity:
                     log_message += str(reset - now_sec)
                     log_message += " secs"
                     self.__logger.warning(log_message)
-                    time.sleep(reset - now_sec)
+                    sleep_duration = reset - now_sec
+                    if sleep_duration > 0:
+                        time.sleep(reset - now_sec)
                 code = 0
             # pylint: disable=W0703
             except Exception as e:

--- a/src/githubcity/ghcity.py
+++ b/src/githubcity/ghcity.py
@@ -520,16 +520,19 @@ class GitHubCity:
             except urllib.error.URLError as e:
                 if hasattr(e, "getheader"):
                     reset = int(e.getheader("X-RateLimit-Reset"))
-                    utcAux = datetime.datetime.utcnow()
-                    utcAux = utcAux.utctimetuple()
-                    now_sec = calendar.timegm(utcAux)
-                    log_message = "Limit of API. Wait: "
-                    log_message += str(reset - now_sec)
-                    log_message += " secs"
+                    if reset < 0:
+                        log_message = "Error when reading response. Wait: 30 secs"
+                        sleep_duration = 30
+                    else:
+                        utcAux = datetime.datetime.utcnow()
+                        utcAux = utcAux.utctimetuple()
+                        now_sec = calendar.timegm(utcAux)
+                        sleep_duration = reset - now_sec
+                        log_message = "Limit of API. Wait: "
+                        log_message += str(sleep_duration)
+                        log_message += " secs"
                     self.__logger.warning(log_message)
-                    sleep_duration = reset - now_sec
-                    if sleep_duration > 0:
-                        time.sleep(reset - now_sec)
+                    time.sleep(sleep_duration)
                 code = 0
             # pylint: disable=W0703
             except Exception as e:


### PR DESCRIPTION
## Purpose
Fix #123, bug when reset time causes sleep duration to be negative

## Approach
Don't sleep if duration is not positive.

