### PR TITLE
Refactor getSortedUsers method on GitHubCity class

### DIFF
--- a/src/githubcity/ghcity.py
+++ b/src/githubcity/ghcity.py
@@ -408,27 +408,10 @@ class GitHubCity:
         :return: a list of the github users sorted by the selected field.
         :rtype: str.
         """
-        if order == "contributions":
-            self.__dataUsers.sort(key=lambda u: u.contributions,
-                                  reverse=True)
-        elif order == "public":
-            self.__dataUsers.sort(key=lambda u: u.public,
-                                  reverse=True)
-        elif order == "private":
-            self.__dataUsers.sort(key=lambda u: u.private,
-                                  reverse=True)
-        elif order == "name":
-            self.__dataUsers.sort(key=lambda u: u.name, reverse=True)
-        elif order == "followers":
-            self.__dataUsers.sort(key=lambda u: u.followers, reverse=True)
-        elif order == "join":
-            self.__dataUsers.sort(key=lambda u: u.join, reverse=True)
-        elif order == "organizations":
-            self.__dataUsers.sort(key=lambda u: u.organizations,
-                                  reverse=True)
-        elif order == "repositories":
-            self.__dataUsers.sort(key=lambda u: u.repositories,
-                                  reverse=True)
+        try:
+            self.__dataUsers.sort(key=lambda u: getattr(u, order), reverse=True)
+        except AttributeError:
+            pass
         return self.__dataUsers
 
     def __exportUsers(self, sort, limit=0):


### PR DESCRIPTION
## Purpose
Refactor `getSortedUsers` method.

## Approach
Use the built-in `getattr` to access the attribute named in the `order` parameter for the function call. This removes some code, and allows any future attributes on the `GitHubUser` class to be sorted without adding it in `getSortedUsers`.

