### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ python setup.py install
 [This library is available to be installed using pip.](https://pypi.python.org/pypi?:action=display&name=githubcity)
 
 ```shell
-pip install github
+pip install githubcity
 ```
 
 


### PR DESCRIPTION
## Purpose
Small fix to readme. Pip instructions state wrong package.
