### PR TITLE
Remove if-else from ghregion

### DIFF
--- a/src/githubcity/ghregion.py
+++ b/src/githubcity/ghregion.py
@@ -124,25 +124,8 @@ class GitHubRegion():
         :return: a list of the github users sorted by the selected field.
         :rtype: str.
         """
-        if order == "contributions":
-            self.__users.sort(key=lambda u: u["contributions"],
-                              reverse=True)
-        elif order == "public":
-            self.__users.sort(key=lambda u: u["public"],
-                              reverse=True)
-        elif order == "private":
-            self.__users.sort(key=lambda u: u["private"],
-                              reverse=True)
-        elif order == "name":
-            self.__users.sort(key=lambda u: u["name"], reverse=True)
-        elif order == "followers":
-            self.__users.sort(key=lambda u: u["followers"], reverse=True)
-        elif order == "join":
-            self.__users.sort(key=lambda u: u["join"], reverse=True)
-        elif order == "organizations":
-            self.__users.sort(key=lambda u: u["organizations"],
-                              reverse=True)
-        elif order == "repositories":
-            self.__users.sort(key=lambda u: u["repositories"],
-                              reverse=True)
-        return self.__users
+		try:
+			self.__users.sort(key=lambda u: getattr(u, order), reverse=True)
+        except AttributeError:
+        pass 
+		return self.__users


### PR DESCRIPTION
## Purpose
Remove if-else from `getSortedUsers` in ghregion.

## Approach
Use the same approach as instructed by @iblancasa in [#163,](https://github.com/iblancasa/GitHubCity/issues/163) to utilize the `getattr` method instead of the if else statement used beforehand. 

## New Issues/FIXME?
I noticed several links in the Contributing.md file aren't working and these needs to be fixed in later issues.

